### PR TITLE
Combined "key" and "path" properties in registry entries

### DIFF
--- a/oc2edr.md
+++ b/oc2edr.md
@@ -424,10 +424,9 @@ The list of external namespace Targets extend the Target list to include Targets
 
 | ID | Name | Type | # | Description |
 | :--- | :--- | :--- | :---: | :--- |
-| 1 | **path** | String | 1 | The absolute path of the registry entry including the hive and optionally the key. If the key is not included then the key property MUST be populated.|
-| 2 | **key** | String | 0\.\.1 | The registry key. They key may contain subkeys referenced with a backslash to indicate hierarchy. |
-| 3 | **type** | String | 1 | The registry value type as defined in [[Winnt.h header]](#winnth-registry-types). |
-| 4 | **value** | String | 0\.\.1 | The value of the registry key. The actuator is responsible to format the value in accordance with the defined type. |
+| 1 | **key** | String | 0\.\.1 | Specifies the full registry key including the hive. |
+| 2 | **type** | String | 1 | The registry value type as defined in the [[Winnt.h header]](#winnth-registry-types). |
+| 3 | **value** | String | 0\.\.1 | The value of the registry key. The Actuator is responsible to format the value in accordance with the defined type. |
 
 **Table 2.1.3-2. Account**
 
@@ -828,15 +827,18 @@ OpenC2 Consumers thet receive a 'set ipv4_net' Command:
 Sets the 'value' property of a Registry Entry. The 'type' property MUST be populated and MUST conform to the registry entry types as defined in [Winnt.h header](#winnth-registry-types).
 
 OpenC2 Producers that send 'set er:registry_entry' Commands:
-* MUST include the 'path' property of the er:registry_entry Target
-* MUST refer to the registry key
-    * SHOULD refer to the registry key using the 'key' property
-    * MAY refer to the registry key by including the key in the 'path' property
+* MUST populate the 'type' property
 
 OpenC2 Consumers that receive a'set er:registry_entry' Command:
-
+* but the 'type' property is not populated
+    * MUST NOT respond with status code OK/200
+    * SHOULD respond with status code 400
+    * MAY respond with status code 500
+    * SHOULD respond with "Registry entry type not specified" in the status text
 * but cannot access the registry entry specified in the registry entry Target
-    * MUST respond with status code 500
+    * MUST NOT respond with status code OK/200
+    * SHOULD respond with status code 400
+    * MAY respond with status code 500
     * SHOULD respond with "Cannot access registry entry" in the status text
 
 


### PR DESCRIPTION
Having both is redundant, and having a bunch of clauses for how to use the properties was clunky.